### PR TITLE
Fix mcmcplots installation failure (resolves #16)

### DIFF
--- a/install_r_packages.sh
+++ b/install_r_packages.sh
@@ -150,13 +150,18 @@ fi
 echo
 echo "📦 Installing additional packages ..."
 
-# Install mcmcplots from CRAN archive using pak
-echo -n "📦 Installing mcmcplots from CRAN archive with pak... "
+# Install mcmcplots from CRAN archive using install.packages() (pak fails with this package)
+echo -n "📦 Installing mcmcplots from CRAN archive with install.packages()... "
 mcmcplots_command="
-library(pak)
 tryCatch({
-    pak::pkg_install('https://cran.r-project.org/src/contrib/Archive/mcmcplots/mcmcplots_0.4.3.tar.gz')
-    cat('SUCCESS\\n')
+    install.packages('https://cran.r-project.org/src/contrib/Archive/mcmcplots/mcmcplots_0.4.3.tar.gz', 
+                     repos = NULL, type = 'source', dependencies = TRUE, quiet = TRUE)
+    if (require('mcmcplots', character.only = TRUE, quietly = TRUE)) {
+        cat('SUCCESS\\n')
+    } else {
+        cat('FAILED TO LOAD\\n')
+        quit(status = 1)
+    }
 }, error = function(e) {
     cat('ERROR:', conditionMessage(e), '\\n')
     quit(status = 1)


### PR DESCRIPTION
## Problem
The `mcmcplots` package was failing to install via `pak`, causing the container build to fail with the error shown in issue #16.

## Solution
Replaced the `pak`-based installation of `mcmcplots` with conventional `install.packages()` as suggested in the issue.

## Changes Made
- Changed from `pak::pkg_install()` to `install.packages()` for mcmcplots package
- Used proper parameters: `repos = NULL`, `type = 'source'`, `dependencies = TRUE`
- Added `require()` check to verify package loads correctly after installation
- Updated comments to explain why `pak` fails with this package

## Technical Details
The fix uses:
```r
install.packages('https://cran.r-project.org/src/contrib/Archive/mcmcplots/mcmcplots_0.4.3.tar.gz', 
                 repos = NULL, type = 'source', dependencies = TRUE, quiet = TRUE)
```

Instead of:
```r
pak::pkg_install('https://cran.r-project.org/src/contrib/Archive/mcmcplots/mcmcplots_0.4.3.tar.gz')
```

## Validation
- Script syntax validated
- R command syntax tested
- No other code changes required

Closes #16