### PR TITLE
Fix build script size reporting and local variable error

### DIFF
--- a/build-container.sh
+++ b/build-container.sh
@@ -85,30 +85,12 @@ print_size_info() {
   local image_ref="$1"
   local metadata_file="$2"
   
-  # Print compressed (push) size from BuildKit metadata if available
-  # command -v checks if 'jq' (JSON processor) is installed, >/dev/null 2>&1 hides output
-  # [ -s "${metadata_file}" ] checks if the metadata file exists and is not empty
-  if command -v jq >/dev/null 2>&1 && [ -s "${metadata_file}" ]; then
-    # jq extracts the container image size from JSON metadata
-    # -r = raw output (no quotes), // empty = fallback if field doesn't exist
-    # || true prevents script from failing if jq command has issues
-    compressed_bytes=$(jq -r '."containerimage.descriptor".size // empty' "${metadata_file}" || true)
-    # Check if we got a valid size value (not empty and not JSON null)
-    if [ -n "${compressed_bytes}" ] && [ "${compressed_bytes}" != "null" ]; then
-      echo "📦 Compressed (push) size: $(human_size "${compressed_bytes}")"
-    else
-      echo "📦 Compressed (push) size: unavailable (no descriptor in metadata)"
-    fi
-  else
-    echo "📦 Compressed (push) size: unavailable (metadata file missing or jq not installed)"
-  fi
-
   # Print uncompressed local image size
   uncompressed_bytes=$(docker image inspect "${image_ref}" --format '{{.Size}}' 2>/dev/null || true)
   if [ -n "${uncompressed_bytes}" ]; then
-    echo "🗜️  Uncompressed (local) size: $(human_size "${uncompressed_bytes}")"
+    echo "🗜️  Image size: $(human_size "${uncompressed_bytes}")"
   else
-    echo "🗜️  Uncompressed (local) size: unavailable"
+    echo "🗜️  Image size: unavailable"
   fi
 
   # Show recent layer sizes/commands for quick feedback
@@ -639,7 +621,7 @@ if [ "$TEST_CONTAINER" = "true" ]; then
     # Single target testing (existing logic)
     echo "🧪 Testing container..."
     TEST_FAIL=0
-    local container_ref="${CONTAINER_NAME}:${IMAGE_TAG}"
+    container_ref="${CONTAINER_NAME}:${IMAGE_TAG}"
 
     echo "🔧 Testing basic system tools..."
     run_in_container "$container_ref" "which zsh"


### PR DESCRIPTION
## Summary

This PR fixes two issues in the build script:

### 1. Misleading Size Reporting
- **Problem**: The "Compressed (push) size: 856B" was actually showing the size of the image manifest descriptor, not the actual compressed image size
- **Root Cause**: The BuildKit metadata `containerimage.descriptor.size` field contains the manifest size (856 bytes), not the total compressed image layers
- **Fix**: Removed the misleading compressed size calculation and simplified to show only the accurate uncompressed image size

### 2. Bash Syntax Error
- **Problem**: `./build-container.sh: line 642: local: can only be used in a function`
- **Root Cause**: `local container_ref=` was used in the main script context instead of inside a function
- **Fix**: Changed to regular variable assignment `container_ref=`

## Changes

**Before:**
```
📦 Compressed (push) size: 856B          # ❌ Misleading - this was manifest size
🗜️  Uncompressed (local) size: 853M      # ✅ Accurate
```

**After:**
```
🗜️  Image size: 853M                     # ✅ Clear and accurate
```

## Testing

- [x] Build script runs without syntax errors
- [x] Size reporting shows accurate information
- [x] No dependency on `jq` for basic size reporting

## Impact

- **Users get accurate size information** instead of confusing/misleading data
- **Build script works reliably** without bash syntax errors
- **Simpler, more maintainable code** with fewer dependencies